### PR TITLE
Generating UUIDs in Java rather than via POST

### DIFF
--- a/src/com/ashafa/clutch.clj
+++ b/src/com/ashafa/clutch.clj
@@ -269,6 +269,9 @@
    :delete
    :command (:name db-meta)))
 
+(defn get-uuid []
+  (str (. java.util.UUID randomUUID)))
+
 (defn replicate-database
   "Takes two arguments (a source and target for replication) which could be a
    string (name of a database in the default Clutch configuration) or a map that
@@ -332,7 +335,7 @@
                   (assoc options :since last-update))]
     (when last-update
       (dosync
-       (let [uid     (str (java.util.UUID/randomUUID))
+       (let [uid    (get-uuid)
              watcher {:uid        uid
                       :http-agent (h/http-agent 
                                    (str url-str "/_changes" (utils/map-to-query-str options false))
@@ -434,10 +437,12 @@
   ([document-map]
      (create-document document-map nil))
   ([document-map id]
-     (if-let [new-document-meta (couchdb-request config (if (nil? id) :post :put)
-                                  :command (utils/uri-encode id)
-                                  :data document-map)]
-       (assoc document-map :_rev (new-document-meta :rev) :_id (new-document-meta :id)))))
+     (let [id (or id (get-uuid))]
+       (if-let [new-document-meta
+                (couchdb-request config :put
+                                 :command (utils/uri-encode id)
+                                 :data document-map)]
+         (assoc document-map :_rev (new-document-meta :rev) :_id (new-document-meta :id))))))
 
 (defn dissoc-meta
   "dissoc'es the :_id and :_rev slots from the provided map."
@@ -577,10 +582,13 @@ their values (see: #'clojure.core/update-in)."
      (bulk-update documents-vector update-map nil))
   ([documents-vector update-map options-map]
      (couchdb-request config :post
-       :command "_bulk_docs"
-       :data (merge {:docs (if update-map
-                             (map #(merge % update-map) documents-vector)
-                             documents-vector)} options-map))))
+                      :command "_bulk_docs"
+                      :data (merge {:docs (if update-map
+                                            (map #(merge % update-map) documents-vector)
+                                            (map #(if (:_id %)
+                                                    %
+                                                    (assoc % :_id (get-uuid)))
+                                                 documents-vector))} options-map))))
 
 (defn update-attachment
   "Takes a document, file (either a string path to the file, a java.io.File object, or an InputStream)


### PR DESCRIPTION
I was prepping for an article I'm working on and was looking into how Clutch handled documents that don't have an ID.  Currently it's using POST, but when I was reading http://wiki.apache.org/couchdb/HTTP_Document_API#POST I found "It is recommended that you avoid POST when possible, because proxies and other network intermediaries will occasionally resend POST requests, which can result in duplicate document creation".  I made the change to gen the IDs in Clutch instead (using java.util.UUID/randomUUID).

-Ryan
