### PR TITLE
Remove reflective calls throughout Clutch

### DIFF
--- a/src/com/ashafa/clutch/utils.clj
+++ b/src/com/ashafa/clutch/utils.clj
@@ -27,7 +27,9 @@
   com.ashafa.clutch.utils
   (:require [clojure.contrib.json :as json])
   (:use clojure.contrib.core)
-  (:import java.net.URLEncoder))
+  (:import java.net.URLEncoder
+           java.lang.Class
+           [java.io File InputStream]))
 
 (defn uri-encode
   [string]
@@ -55,7 +57,7 @@
 (defn set-field
   "Set to private or protected field. field-name is a symbol or keyword.
    This will presumably be added to clojure.contrib.reflect eventually...?"
-  [klass field-name obj value]
+  [^Class klass field-name obj value]
   (-> klass
     (.getDeclaredField (name field-name))
     (doto (.setAccessible true))
@@ -84,12 +86,12 @@
      :name     (.getPath java-url)}))
 
 (defn get-mime-type
-  [file]
+  [^File file]
   (.getContentType
    (javax.activation.MimetypesFileTypeMap.) file))
 
 (defn convert-input-to-bytes
-  [input]
+  [^InputStream input]
   (let [barr (make-array Byte/TYPE 1024)
         out  (java.io.ByteArrayOutputStream.)]
     (loop [r (.read input barr)]
@@ -100,6 +102,6 @@
     (.toByteArray out)))
 
 (defn encode-bytes-to-base64
-  [bytes]
+  [^bytes bytes]
   (.replaceAll
    (.encode (sun.misc.BASE64Encoder.) bytes) "\n" ""))

--- a/src/com/ashafa/clutchapp.clj
+++ b/src/com/ashafa/clutchapp.clj
@@ -66,7 +66,7 @@
    returning a seq of [:filename content] vectors.  Note that file
    extensions are trimmed in the process of creating :filename."
   [dir paths]
-  (for [path paths
+  (for [^String path paths
         :let [f (jio/file dir path)
               dot (.lastIndexOf path ".")]
         :when (.exists f)]
@@ -81,7 +81,7 @@
 
    @todo add support for other languages based on the design doc's
    :language slot, e.g. map.clj, reduce.clj"
-  [view-dir]
+  [^File view-dir]
   {(-> view-dir .getName keyword)
    (into {} (load-files view-dir (map #(str % \. *lang-ext*) ["map" "reduce"])))})
 
@@ -89,7 +89,7 @@
   "Loads all views under the given design document root directory path."
   [design-doc-path]
   (let [views-root (jio/file design-doc-path "views")
-        view-dirs (filter #(.isDirectory %) (.listFiles views-root))]
+        view-dirs (filter #(.isDirectory ^File %) (.listFiles views-root))]
     (->> view-dirs
       (map load-view)
       (reduce merge))))
@@ -125,7 +125,7 @@
   (cond
     (or (string? dir-or-ddocs)
       (instance? File dir-or-ddocs)) (->> dir-or-ddocs jio/file .listFiles
-                                       (filter #(.isDirectory %))
+                                       (filter #(.isDirectory ^File %))
                                        (map load-design-doc))
     (sequential? dir-or-ddocs) dir-or-ddocs
     :else (throw (IllegalArgumentException.
@@ -201,9 +201,10 @@
    content in the destination directory."
   [db-url dest-path]
   (with-db (jio/as-url db-url)
-    (doseq [ddoc-id (->> (get-all-documents-meta {:startkey "_design/"
-                                                  :endkey (str "_design/" *wildcard-collation-string*)})
-                     :rows (map :id))
+    (doseq [^String ddoc-id (->> (get-all-documents-meta
+                                  {:startkey "_design/"
+                                   :endkey (str "_design/" *wildcard-collation-string*)})
+                                 :rows (map :id))
             :let [[_ ddoc-name] (.split ddoc-id "/")]]
       (clone
         (-> db-url (str "/") URL. (URL. ddoc-id) .toExternalForm)


### PR DESCRIPTION
This patch removes 35 reflective calls throughout Clutch, all of them as far as I know that are not caused by other libraries. I examined the code pretty carefully to make sure that these were reasonable changes, and not restricting or changing the semantics of the code. Most of the instances fall under "What else could it possibly be?," with the second most common category being "We just checked if this was an instance of a specific type, but then do the call with reflection." There was also an instance where something had an attempted type hint but it was still causing reflection. 

I did make a slightly more extensive change to generate-attachment-map by changing an anonymous function from #(...) to (fn [x y] ...). This let me hint the variables directly instead of repeatedly throughout the function. I also just kind of thought the function was a bit too long to be easily understood without naming the parameters. I also made some minor changes to import certain Java classes instead of using their.long.Names. I just felt that with the repeated need for hints in certain places, they were adding a bit too much noise to the text of the function. 

This is in response to Issue 12. All tests passing. 
