### PR TITLE
Added uuids function. Added test.

### DIFF
--- a/src/com/ashafa/clutch.clj
+++ b/src/com/ashafa/clutch.clj
@@ -94,6 +94,17 @@
     :data {:source (str srcdb)
            :target (str tgtdb)}))
 
+(defdbop uuids
+  "Returns a list of n fresh UUID's from the server for use as id in future calls
+   to put-document. For the rationale behind preferring PUT requests with
+   pre-generated ids to POST requests when saving new documents, see
+   http://wiki.apache.org/couchdb/HTTP_Document_API."
+  [db n]
+  (couchdb-request :get
+                   (->
+                    (url/url db "/_uuids")
+                    (assoc :query {:count n}))))
+
 (def ^{:private true} byte-array-class (Class/forName "[B"))
 
 (defn- attachment-info

--- a/test/test_clutch.clj
+++ b/test/test_clutch.clj
@@ -171,6 +171,10 @@
   (put-document (first test-docs) :id "some_id")
   (failing-request 409 (put-document (first test-docs) :id "some_id")))
 
+(defdbtest get-two-uuids
+  (let [resp (uuids 2)]
+    (is (= 2 (count (:uuids resp))))))
+
 (defdbtest update-a-document
   (let [id (:_id (put-document (nth test-docs 3)))]
     (update-document (get-document id) {:email "test@example.com"})


### PR DESCRIPTION
I found myself in need for GET /_uuids?count=n to retrieve a list of document ids for subsequent PUT requests (in place of POSTs). This is encouraged here: http://wiki.apache.org/couchdb/HTTP_Document_API
There isn't a convenient wrapper for this, so I added it to clutch, together with a test.
