### PR TITLE
removes quote from fns arg in view-server-fns macro

### DIFF
--- a/src/com/ashafa/clutch.clj
+++ b/src/com/ashafa/clutch.clj
@@ -272,7 +272,7 @@
                              [(or (:language options) :javascript) (dissoc options :language)]
                              [options])]
     [(:language (view-transformer language))
-     `(#'map-leaves ((:compiler (view-transformer ~language)) ~options) '~fns)]))
+     `(#'map-leaves ((:compiler (view-transformer ~language)) ~options) ~fns)]))
 
 (defdbop save-design-document
   "Create/update a design document containing functions used for database


### PR DESCRIPTION
Allows fns argument to be passed by symbol, ie:

```
(view-server-fns :javascript {:confirmed   {:map "function(doc) { emit(doc._id, doc); }"}}))
```

works now, but

```
(def my-map {:confirmed   {:map "function(doc) { emit(doc._id, doc); }"}})
(view-server-fns :javascript my-map)
```

does not. Unquoting should not be a problem since a map evaluates to itself.
